### PR TITLE
Add missing check for zero length bytes string.

### DIFF
--- a/cbor/cbor.py
+++ b/cbor/cbor.py
@@ -260,6 +260,8 @@ def loads(data):
     """
     if data is None:
         raise ValueError("got None for buffer to decode in loads")
+    elif data == b'':
+        raise ValueError("got zero length string loads")
     fp = StringIO(data)
     return _loads(fp)[0]
 


### PR DESCRIPTION
Add a missing check for a zero length bytes string inside loads() and
raise a ValueError in that case.

Previously, the empty string was allowed to propagate, resulting in an
EOFError shortly down the line. This is inconsistent with the C
implementation that raises a ValueError.