### PR TITLE
Import setuptools before distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,12 +16,12 @@
 # Thanks!
 # to Mic Bowman for a bunch of work and impetus on dumps(,sort_keys=)
 
+from setuptools import setup, Extension
+
 from distutils.command.build_ext import build_ext
 from distutils.errors import (CCompilerError, DistutilsExecError,
     DistutilsPlatformError)
 import sys
-
-from setuptools import setup, Extension
 
 
 build_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError)


### PR DESCRIPTION
setuptools 60 uses its own bundled version of distutils, by default. It injects this into sys.modules, at import time. So we need to make sure that it is imported, before anything else imports distutils, to ensure everything is using the same distutils version.

This change in setuptools is to prepare for Python 3.12, which will drop distutils.

Fixes: https://bugs.debian.org/1022525